### PR TITLE
add elabftw data interface

### DIFF
--- a/mease-env.yml
+++ b/mease-env.yml
@@ -38,3 +38,4 @@ dependencies:
     - psutil
     - opencv-python
     - jupyterlab-nvdashboard
+    - mease-elabftw

--- a/mease_lab_to_nwb/convert_ced/cednwbconverter.py
+++ b/mease_lab_to_nwb/convert_ced/cednwbconverter.py
@@ -9,6 +9,7 @@ from nwb_conversion_tools import NWBConverter, CEDRecordingInterface
 from nwb_conversion_tools.utils.spike_interface import write_recording
 
 from .cedstimulusinterface import CEDStimulusInterface
+from .elabftwinterface import ElabftwInterface
 
 
 def quick_write(
@@ -43,7 +44,9 @@ def quick_write(
 
 class CEDNWBConverter(NWBConverter):
     data_interface_classes = dict(
-        CEDRecording=CEDRecordingInterface, CEDStimulus=CEDStimulusInterface
+        CEDRecording=CEDRecordingInterface,
+        CEDStimulus=CEDStimulusInterface,
+        Elabftw=ElabftwInterface,
     )
 
     def __init__(self, source_data):
@@ -67,7 +70,5 @@ class CEDNWBConverter(NWBConverter):
             self.data_interface_objects["CEDRecording"].source_data["file_path"]
         )
         session_id = smrx_file_path.stem
-        metadata["NWBFile"].update(
-            institution="EMBL - Heidelberg", lab="Mease", session_id=session_id
-        )
+        metadata["NWBFile"].update(session_id=session_id)
         return metadata

--- a/mease_lab_to_nwb/convert_ced/cedstimulusinterface.py
+++ b/mease_lab_to_nwb/convert_ced/cedstimulusinterface.py
@@ -112,7 +112,7 @@ class CEDStimulusInterface(BaseRecordingExtractorInterface):
                 type=source_schema["properties"]["file_path"]["type"],
                 format="file",
                 description="path to data file",
-            )
+            ),
         )
         return source_schema
 
@@ -167,6 +167,7 @@ class CEDStimulusInterface(BaseRecordingExtractorInterface):
             excitation_lambda=1.0,
             location="location",
         )
+
         laser_trace = recording.get_traces(2)[0]
         if laser_power_mw:
             # rescale laser trace

--- a/mease_lab_to_nwb/convert_ced/elabftwinterface.py
+++ b/mease_lab_to_nwb/convert_ced/elabftwinterface.py
@@ -1,0 +1,23 @@
+from nwb_conversion_tools.basedatainterface import BaseDataInterface
+from pynwb import NWBFile
+import mease_elabftw
+
+
+class ElabftwInterface(BaseDataInterface):
+    """Data interface for importing experiment metadata from elabftw"""
+
+    @classmethod
+    def get_source_schema(cls):
+        return dict(properties=dict(experiment_id=dict(type="number")))
+
+    def get_metadata(self):
+        experiment_id = self.source_data.get("experiment_id")
+        if experiment_id is None:
+            return {}
+        metadata = mease_elabftw.get_nwb_metadata(experiment_id)
+        # temporary hacks to pass schema validation
+        del metadata["Other"]
+        return metadata
+
+    def run_conversion(self, nwbfile: NWBFile, metadata: dict):
+        return

--- a/notebooks/CED_spikeinterface_pipeline.ipynb
+++ b/notebooks/CED_spikeinterface_pipeline.ipynb
@@ -903,9 +903,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 64-bit ('env_movshon': conda)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3710jvsc74a57bd06c19ac61565dac34ec9dee5220d86c85d7bb9cb26471bf3e794769e7dfcdf603"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -917,16 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "metadata": {
-     "collapsed": false
-    },
-    "source": []
-   }
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ndx-events
 edlio
 crc32c
 nwb-conversion-tools
+mease-elabftw


### PR DESCRIPTION
- extracts NWB metadata from an ElabFTW experiment using mease-elabftw (https://pypi.org/project/mease-elabftw)
- experiment id is passed to CEDNWBConverter as `Elabftw` entry in `source_data`, e.g. `Elabftw=dict(experiment_id=123)`
- `experiment_id` is optional, if not specified then no metadata is added by this data infterface
- tests mock `mease_elabftw.get_nwb_metadata` with `mease_elabftw.nwb.get_sample_nwb_metadata` to avoid needing a valid ElabFTW API token
